### PR TITLE
Task 005 - Create sub-tasks as nested resources

### DIFF
--- a/lib/taskify/sub_tasks.ex
+++ b/lib/taskify/sub_tasks.ex
@@ -7,6 +7,7 @@ defmodule Taskify.SubTasks do
   alias Taskify.Repo
 
   alias Taskify.SubTasks.SubTask
+  alias Taskify.Tasks.Task
 
   @doc """
   Returns the list of sub_tasks.
@@ -17,8 +18,14 @@ defmodule Taskify.SubTasks do
       [%SubTask{}, ...]
 
   """
-  def list_sub_tasks do
-    Repo.all(SubTask)
+  def list_sub_tasks(task) do
+    SubTask
+    |> task_sub_tasks_query(task)
+    |> Repo.all()
+  end
+
+  defp task_sub_tasks_query(query, %Task{id: task_id}) do
+    from(t in query, where: t.task_id == ^task_id, preload: [task: :user])
   end
 
   @doc """
@@ -35,23 +42,28 @@ defmodule Taskify.SubTasks do
       ** (Ecto.NoResultsError)
 
   """
-  def get_sub_task!(id), do: Repo.get!(SubTask, id)
+  def get_sub_task!(task, id) do
+    SubTask
+    |> task_sub_tasks_query(task)
+    |> Repo.get!(id)
+  end
 
   @doc """
   Creates a sub_task.
 
   ## Examples
 
-      iex> create_sub_task(%{field: value})
+      iex> create_sub_task(task, %{field: value})
       {:ok, %SubTask{}}
 
-      iex> create_sub_task(%{field: bad_value})
+      iex> create_sub_task(task, %{field: bad_value})
       {:error, %Ecto.Changeset{}}
 
   """
-  def create_sub_task(attrs \\ %{}) do
+  def create_sub_task(task, attrs \\ %{}) do
     %SubTask{}
     |> SubTask.changeset(attrs)
+    |> Ecto.Changeset.put_assoc(:task, task)
     |> Repo.insert()
   end
 

--- a/lib/taskify/sub_tasks.ex
+++ b/lib/taskify/sub_tasks.ex
@@ -1,0 +1,104 @@
+defmodule Taskify.SubTasks do
+  @moduledoc """
+  The SubTasks context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Taskify.Repo
+
+  alias Taskify.SubTasks.SubTask
+
+  @doc """
+  Returns the list of sub_tasks.
+
+  ## Examples
+
+      iex> list_sub_tasks()
+      [%SubTask{}, ...]
+
+  """
+  def list_sub_tasks do
+    Repo.all(SubTask)
+  end
+
+  @doc """
+  Gets a single sub_task.
+
+  Raises `Ecto.NoResultsError` if the Sub task does not exist.
+
+  ## Examples
+
+      iex> get_sub_task!(123)
+      %SubTask{}
+
+      iex> get_sub_task!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_sub_task!(id), do: Repo.get!(SubTask, id)
+
+  @doc """
+  Creates a sub_task.
+
+  ## Examples
+
+      iex> create_sub_task(%{field: value})
+      {:ok, %SubTask{}}
+
+      iex> create_sub_task(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_sub_task(attrs \\ %{}) do
+    %SubTask{}
+    |> SubTask.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a sub_task.
+
+  ## Examples
+
+      iex> update_sub_task(sub_task, %{field: new_value})
+      {:ok, %SubTask{}}
+
+      iex> update_sub_task(sub_task, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_sub_task(%SubTask{} = sub_task, attrs) do
+    sub_task
+    |> SubTask.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a sub_task.
+
+  ## Examples
+
+      iex> delete_sub_task(sub_task)
+      {:ok, %SubTask{}}
+
+      iex> delete_sub_task(sub_task)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_sub_task(%SubTask{} = sub_task) do
+    Repo.delete(sub_task)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking sub_task changes.
+
+  ## Examples
+
+      iex> change_sub_task(sub_task)
+      %Ecto.Changeset{data: %SubTask{}}
+
+  """
+  def change_sub_task(%SubTask{} = sub_task, attrs \\ %{}) do
+    SubTask.changeset(sub_task, attrs)
+  end
+end

--- a/lib/taskify/sub_tasks/sub_task.ex
+++ b/lib/taskify/sub_tasks/sub_task.ex
@@ -2,11 +2,13 @@ defmodule Taskify.SubTasks.SubTask do
   use Ecto.Schema
   import Ecto.Changeset
 
+  alias Taskify.Tasks.Task
+
   schema "sub_tasks" do
     field :completed, :boolean, default: false
     field :description, :string
     field :name, :string
-    field :task_id, :id
+    belongs_to :task, Task
 
     timestamps()
   end

--- a/lib/taskify/sub_tasks/sub_task.ex
+++ b/lib/taskify/sub_tasks/sub_task.ex
@@ -1,0 +1,20 @@
+defmodule Taskify.SubTasks.SubTask do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "sub_tasks" do
+    field :completed, :boolean, default: false
+    field :description, :string
+    field :name, :string
+    field :task_id, :id
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(sub_task, attrs) do
+    sub_task
+    |> cast(attrs, [:name, :description, :completed])
+    |> validate_required([:name, :description, :completed])
+  end
+end

--- a/lib/taskify/tasks/task.ex
+++ b/lib/taskify/tasks/task.ex
@@ -2,12 +2,14 @@ defmodule Taskify.Tasks.Task do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias Taskify.Accounts.User
+  alias Taskify.{Accounts.User, SubTasks.SubTask}
 
   schema "tasks" do
     field :description, :string
     field :name, :string
     belongs_to :user, User
+
+    has_many :sub_tasks, SubTask
 
     timestamps()
   end

--- a/lib/taskify_web/controllers/sub_task_controller.ex
+++ b/lib/taskify_web/controllers/sub_task_controller.ex
@@ -62,9 +62,17 @@ defmodule TaskifyWeb.SubTaskController do
     end
   end
 
+  def delete(conn, %{"task_id" => _task_id, "id" => id}, task) do
+    sub_task = SubTasks.get_sub_task!(task, id)
+    {:ok, _sub_task} = SubTasks.delete_sub_task(sub_task)
+
+    conn
+    |> put_flash(:info, "Sub task deleted successfully.")
+    |> redirect(to: Routes.task_sub_task_path(conn, :index, task))
+  end
+
   defp fetch_task(conn, _opts) do
     task = Tasks.get_user_task!(conn.assigns.current_user, conn.params["task_id"])
     assign(conn, :task, task)
   end
-
 end

--- a/lib/taskify_web/controllers/sub_task_controller.ex
+++ b/lib/taskify_web/controllers/sub_task_controller.ex
@@ -2,6 +2,7 @@ defmodule TaskifyWeb.SubTaskController do
   use TaskifyWeb, :controller
 
   alias Taskify.{SubTasks, Tasks}
+  alias Taskify.SubTasks.SubTask
 
   def action(conn, _) do
     args = [conn, conn.params, conn.assigns.current_user]
@@ -13,4 +14,11 @@ defmodule TaskifyWeb.SubTaskController do
     sub_tasks = SubTasks.list_sub_tasks(task)
     render(conn, "index.html", sub_tasks: sub_tasks, task: task)
   end
+
+  def new(conn, %{"task_id" => task_id}, current_user) do
+    task = Tasks.get_user_task!(current_user, task_id)
+    changeset = SubTasks.change_sub_task(%SubTask{})
+    render(conn, "new.html", changeset: changeset, task: task)
+  end
+
 end

--- a/lib/taskify_web/controllers/sub_task_controller.ex
+++ b/lib/taskify_web/controllers/sub_task_controller.ex
@@ -4,21 +4,26 @@ defmodule TaskifyWeb.SubTaskController do
   alias Taskify.{SubTasks, Tasks}
   alias Taskify.SubTasks.SubTask
 
+  plug :fetch_task
+
   def action(conn, _) do
-    args = [conn, conn.params, conn.assigns.current_user]
+    args = [conn, conn.params, conn.assigns.task]
     apply(__MODULE__, action_name(conn), args)
   end
 
-  def index(conn, %{"task_id" => task_id}, current_user) do
-    task = Tasks.get_user_task!(current_user, task_id)
+  def index(conn, %{"task_id" => _task_id}, task) do
     sub_tasks = SubTasks.list_sub_tasks(task)
     render(conn, "index.html", sub_tasks: sub_tasks, task: task)
   end
 
-  def new(conn, %{"task_id" => task_id}, current_user) do
-    task = Tasks.get_user_task!(current_user, task_id)
+  def new(conn, %{"task_id" => _task_id}, task) do
     changeset = SubTasks.change_sub_task(%SubTask{})
     render(conn, "new.html", changeset: changeset, task: task)
+  end
+
+  defp fetch_task(conn, _opts) do
+    task = Tasks.get_user_task!(conn.assigns.current_user, conn.params["task_id"])
+    assign(conn, :task, task)
   end
 
 end

--- a/lib/taskify_web/controllers/sub_task_controller.ex
+++ b/lib/taskify_web/controllers/sub_task_controller.ex
@@ -1,0 +1,16 @@
+defmodule TaskifyWeb.SubTaskController do
+  use TaskifyWeb, :controller
+
+  alias Taskify.{SubTasks, Tasks}
+
+  def action(conn, _) do
+    args = [conn, conn.params, conn.assigns.current_user]
+    apply(__MODULE__, action_name(conn), args)
+  end
+
+  def index(conn, %{"task_id" => task_id}, current_user) do
+    task = Tasks.get_user_task!(current_user, task_id)
+    sub_tasks = SubTasks.list_sub_tasks(task)
+    render(conn, "index.html", sub_tasks: sub_tasks)
+  end
+end

--- a/lib/taskify_web/controllers/sub_task_controller.ex
+++ b/lib/taskify_web/controllers/sub_task_controller.ex
@@ -11,6 +11,6 @@ defmodule TaskifyWeb.SubTaskController do
   def index(conn, %{"task_id" => task_id}, current_user) do
     task = Tasks.get_user_task!(current_user, task_id)
     sub_tasks = SubTasks.list_sub_tasks(task)
-    render(conn, "index.html", sub_tasks: sub_tasks)
+    render(conn, "index.html", sub_tasks: sub_tasks, task: task)
   end
 end

--- a/lib/taskify_web/controllers/sub_task_controller.ex
+++ b/lib/taskify_web/controllers/sub_task_controller.ex
@@ -38,6 +38,30 @@ defmodule TaskifyWeb.SubTaskController do
     render(conn, "show.html", sub_task: sub_task, task: task)
   end
 
+  def edit(conn, %{"task_id" => _task_id, "id" => id}, task) do
+    sub_task = SubTasks.get_sub_task!(task, id)
+    changeset = SubTasks.change_sub_task(sub_task)
+    render(conn, "edit.html", sub_task: sub_task, changeset: changeset, task: task)
+  end
+
+  def update(
+        conn,
+        %{"task_id" => _task_id, "id" => id, "sub_task" => sub_task_params},
+        task
+      ) do
+    sub_task = SubTasks.get_sub_task!(task, id)
+
+    case SubTasks.update_sub_task(sub_task, sub_task_params) do
+      {:ok, sub_task} ->
+        conn
+        |> put_flash(:info, "Sub task updated successfully.")
+        |> redirect(to: Routes.task_sub_task_path(conn, :show, task, sub_task))
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        render(conn, "edit.html", sub_task: sub_task, changeset: changeset, task: task)
+    end
+  end
+
   defp fetch_task(conn, _opts) do
     task = Tasks.get_user_task!(conn.assigns.current_user, conn.params["task_id"])
     assign(conn, :task, task)

--- a/lib/taskify_web/controllers/sub_task_controller.ex
+++ b/lib/taskify_web/controllers/sub_task_controller.ex
@@ -21,6 +21,23 @@ defmodule TaskifyWeb.SubTaskController do
     render(conn, "new.html", changeset: changeset, task: task)
   end
 
+  def create(conn, %{"task_id" => _task_id, "sub_task" => sub_task_params}, task) do
+    case SubTasks.create_sub_task(task, sub_task_params) do
+      {:ok, sub_task} ->
+        conn
+        |> put_flash(:info, "Sub task created successfully.")
+        |> redirect(to: Routes.task_sub_task_path(conn, :show, task, sub_task))
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        render(conn, "new.html", changeset: changeset, task: task)
+    end
+  end
+
+  def show(conn, %{"task_id" => _task_id, "id" => id}, task) do
+    sub_task = SubTasks.get_sub_task!(task, id)
+    render(conn, "show.html", sub_task: sub_task, task: task)
+  end
+
   defp fetch_task(conn, _opts) do
     task = Tasks.get_user_task!(conn.assigns.current_user, conn.params["task_id"])
     assign(conn, :task, task)

--- a/lib/taskify_web/router.ex
+++ b/lib/taskify_web/router.ex
@@ -26,7 +26,9 @@ defmodule TaskifyWeb.Router do
   scope "/", TaskifyWeb do
     pipe_through [:browser, :require_authenticated_user]
 
-    resources "/tasks", TaskController
+    resources "/tasks", TaskController do
+      resources "/sub_tasks", SubTaskController
+    end
   end
 
   # Other scopes may use custom stacks.

--- a/lib/taskify_web/templates/sub_task/edit.html.heex
+++ b/lib/taskify_web/templates/sub_task/edit.html.heex
@@ -1,0 +1,5 @@
+<h1>Edit Sub task</h1>
+
+<%= render "form.html", Map.put(assigns, :action, Routes.sub_task_path(@conn, :update, @sub_task)) %>
+
+<span><%= link "Back", to: Routes.sub_task_path(@conn, :index) %></span>

--- a/lib/taskify_web/templates/sub_task/edit.html.heex
+++ b/lib/taskify_web/templates/sub_task/edit.html.heex
@@ -1,5 +1,5 @@
 <h1>Edit Sub task</h1>
 
-<%= render "form.html", Map.put(assigns, :action, Routes.sub_task_path(@conn, :update, @sub_task)) %>
+<%= render "form.html", Map.put(assigns, :action, Routes.task_sub_task_path(@conn, :update, @task, @sub_task)) %>
 
-<span><%= link "Back", to: Routes.sub_task_path(@conn, :index) %></span>
+<span><%= link "Back", to: Routes.task_sub_task_path(@conn, :index, @task) %></span>

--- a/lib/taskify_web/templates/sub_task/form.html.heex
+++ b/lib/taskify_web/templates/sub_task/form.html.heex
@@ -1,0 +1,23 @@
+<.form let={f} for={@changeset} action={@action}>
+  <%= if @changeset.action do %>
+    <div class="alert alert-danger">
+      <p>Oops, something went wrong! Please check the errors below.</p>
+    </div>
+  <% end %>
+
+  <%= label f, :name %>
+  <%= text_input f, :name %>
+  <%= error_tag f, :name %>
+
+  <%= label f, :description %>
+  <%= textarea f, :description %>
+  <%= error_tag f, :description %>
+
+  <%= label f, :completed %>
+  <%= checkbox f, :completed %>
+  <%= error_tag f, :completed %>
+
+  <div>
+    <%= submit "Save" %>
+  </div>
+</.form>

--- a/lib/taskify_web/templates/sub_task/index.html.heex
+++ b/lib/taskify_web/templates/sub_task/index.html.heex
@@ -18,13 +18,13 @@
       <td><%= sub_task.completed %></td>
 
       <td>
-        <span><%= link "Show", to: Routes.sub_task_path(@conn, :show, sub_task) %></span>
-        <span><%= link "Edit", to: Routes.sub_task_path(@conn, :edit, sub_task) %></span>
-        <span><%= link "Delete", to: Routes.sub_task_path(@conn, :delete, sub_task), method: :delete, data: [confirm: "Are you sure?"] %></span>
+        <span><%= link "Show", to: Routes.task_sub_task_path(@conn, :show, @task, sub_task) %></span>
+        <span><%= link "Edit", to: Routes.task_sub_task_path(@conn, :edit, @task, sub_task) %></span>
+        <span><%= link "Delete", to: Routes.task_sub_task_path(@conn, :delete, @task, sub_task), method: :delete, data: [confirm: "Are you sure?"] %></span>
       </td>
     </tr>
 <% end %>
   </tbody>
 </table>
 
-<span><%= link "New Sub task", to: Routes.sub_task_path(@conn, :new) %></span>
+<span><%= link "New Sub task", to: Routes.task_sub_task_path(@conn, :new, @task) %></span>

--- a/lib/taskify_web/templates/sub_task/index.html.heex
+++ b/lib/taskify_web/templates/sub_task/index.html.heex
@@ -1,0 +1,26 @@
+<h1>Listing Sub-Tasks</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Description</th>
+      <th>Completed</th>
+
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+<%= for sub_task <- @sub_tasks do %>
+    <tr>
+      <td><%= sub_task.name %></td>
+      <td><%= sub_task.description %></td>
+      <td><%= sub_task.completed %></td>
+
+      <td>
+
+      </td>
+    </tr>
+<% end %>
+  </tbody>
+</table>

--- a/lib/taskify_web/templates/sub_task/index.html.heex
+++ b/lib/taskify_web/templates/sub_task/index.html.heex
@@ -1,4 +1,4 @@
-<h1>Listing Sub-Tasks</h1>
+<h1>Listing Sub tasks</h1>
 
 <table>
   <thead>
@@ -18,9 +18,13 @@
       <td><%= sub_task.completed %></td>
 
       <td>
-
+        <span><%= link "Show", to: Routes.sub_task_path(@conn, :show, sub_task) %></span>
+        <span><%= link "Edit", to: Routes.sub_task_path(@conn, :edit, sub_task) %></span>
+        <span><%= link "Delete", to: Routes.sub_task_path(@conn, :delete, sub_task), method: :delete, data: [confirm: "Are you sure?"] %></span>
       </td>
     </tr>
 <% end %>
   </tbody>
 </table>
+
+<span><%= link "New Sub task", to: Routes.sub_task_path(@conn, :new) %></span>

--- a/lib/taskify_web/templates/sub_task/new.html.heex
+++ b/lib/taskify_web/templates/sub_task/new.html.heex
@@ -1,5 +1,5 @@
 <h1>New Sub task</h1>
 
-<%= render "form.html", Map.put(assigns, :action, Routes.sub_task_path(@conn, :create)) %>
+<%= render "form.html", Map.put(assigns, :action, Routes.task_sub_task_path(@conn, :create, @task)) %>
 
-<span><%= link "Back", to: Routes.sub_task_path(@conn, :index) %></span>
+<span><%= link "Back", to: Routes.task_sub_task_path(@conn, :index, @task) %></span>

--- a/lib/taskify_web/templates/sub_task/new.html.heex
+++ b/lib/taskify_web/templates/sub_task/new.html.heex
@@ -1,0 +1,5 @@
+<h1>New Sub task</h1>
+
+<%= render "form.html", Map.put(assigns, :action, Routes.sub_task_path(@conn, :create)) %>
+
+<span><%= link "Back", to: Routes.sub_task_path(@conn, :index) %></span>

--- a/lib/taskify_web/templates/sub_task/show.html.heex
+++ b/lib/taskify_web/templates/sub_task/show.html.heex
@@ -1,0 +1,23 @@
+<h1>Show Sub task</h1>
+
+<ul>
+
+  <li>
+    <strong>Name:</strong>
+    <%= @sub_task.name %>
+  </li>
+
+  <li>
+    <strong>Description:</strong>
+    <%= @sub_task.description %>
+  </li>
+
+  <li>
+    <strong>Completed:</strong>
+    <%= @sub_task.completed %>
+  </li>
+
+</ul>
+
+<span><%= link "Edit", to: Routes.sub_task_path(@conn, :edit, @sub_task) %></span> |
+<span><%= link "Back", to: Routes.sub_task_path(@conn, :index) %></span>

--- a/lib/taskify_web/templates/sub_task/show.html.heex
+++ b/lib/taskify_web/templates/sub_task/show.html.heex
@@ -19,5 +19,5 @@
 
 </ul>
 
-<span><%= link "Edit", to: Routes.sub_task_path(@conn, :edit, @sub_task) %></span> |
-<span><%= link "Back", to: Routes.sub_task_path(@conn, :index) %></span>
+<span><%= link "Edit", to: Routes.task_sub_task_path(@conn, :edit, @task, @sub_task) %></span> |
+<span><%= link "Back", to: Routes.task_sub_task_path(@conn, :index, @task) %></span>

--- a/lib/taskify_web/views/sub_task_view.ex
+++ b/lib/taskify_web/views/sub_task_view.ex
@@ -1,0 +1,3 @@
+defmodule TaskifyWeb.SubTaskView do
+  use TaskifyWeb, :view
+end

--- a/priv/repo/migrations/20221111011740_create_sub_tasks.exs
+++ b/priv/repo/migrations/20221111011740_create_sub_tasks.exs
@@ -3,10 +3,10 @@ defmodule Taskify.Repo.Migrations.CreateSubTasks do
 
   def change do
     create table(:sub_tasks) do
-      add :name, :string
+      add :name, :string, null: false
       add :description, :text
       add :completed, :boolean, default: false, null: false
-      add :task_id, references(:tasks, on_delete: :nothing)
+      add :task_id, references(:tasks, on_delete: :delete_all), null: false
 
       timestamps()
     end

--- a/priv/repo/migrations/20221111011740_create_sub_tasks.exs
+++ b/priv/repo/migrations/20221111011740_create_sub_tasks.exs
@@ -1,0 +1,16 @@
+defmodule Taskify.Repo.Migrations.CreateSubTasks do
+  use Ecto.Migration
+
+  def change do
+    create table(:sub_tasks) do
+      add :name, :string
+      add :description, :text
+      add :completed, :boolean, default: false, null: false
+      add :task_id, references(:tasks, on_delete: :nothing)
+
+      timestamps()
+    end
+
+    create index(:sub_tasks, [:task_id])
+  end
+end

--- a/test/support/fixtures/sub_tasks_fixtures.ex
+++ b/test/support/fixtures/sub_tasks_fixtures.ex
@@ -7,15 +7,16 @@ defmodule Taskify.SubTasksFixtures do
   @doc """
   Generate a sub_task.
   """
-  def sub_task_fixture(attrs \\ %{}) do
-    {:ok, sub_task} =
+  def sub_task_fixture(task, attrs \\ %{}) do
+    sub_task_attrs =
       attrs
       |> Enum.into(%{
         completed: true,
         description: "some description",
         name: "some name"
       })
-      |> Taskify.SubTasks.create_sub_task()
+
+    {:ok, sub_task} = Taskify.SubTasks.create_sub_task(task, sub_task_attrs)
 
     sub_task
   end

--- a/test/support/fixtures/sub_tasks_fixtures.ex
+++ b/test/support/fixtures/sub_tasks_fixtures.ex
@@ -1,0 +1,22 @@
+defmodule Taskify.SubTasksFixtures do
+  @moduledoc """
+  This module defines test helpers for creating
+  entities via the `Taskify.SubTasks` context.
+  """
+
+  @doc """
+  Generate a sub_task.
+  """
+  def sub_task_fixture(attrs \\ %{}) do
+    {:ok, sub_task} =
+      attrs
+      |> Enum.into(%{
+        completed: true,
+        description: "some description",
+        name: "some name"
+      })
+      |> Taskify.SubTasks.create_sub_task()
+
+    sub_task
+  end
+end

--- a/test/taskify/sub_tasks_test.exs
+++ b/test/taskify/sub_tasks_test.exs
@@ -1,0 +1,63 @@
+defmodule Taskify.SubTasksTest do
+  use Taskify.DataCase
+
+  alias Taskify.SubTasks
+
+  describe "sub_tasks" do
+    alias Taskify.SubTasks.SubTask
+
+    import Taskify.SubTasksFixtures
+
+    @invalid_attrs %{completed: nil, description: nil, name: nil}
+
+    test "list_sub_tasks/0 returns all sub_tasks" do
+      sub_task = sub_task_fixture()
+      assert SubTasks.list_sub_tasks() == [sub_task]
+    end
+
+    test "get_sub_task!/1 returns the sub_task with given id" do
+      sub_task = sub_task_fixture()
+      assert SubTasks.get_sub_task!(sub_task.id) == sub_task
+    end
+
+    test "create_sub_task/1 with valid data creates a sub_task" do
+      valid_attrs = %{completed: true, description: "some description", name: "some name"}
+
+      assert {:ok, %SubTask{} = sub_task} = SubTasks.create_sub_task(valid_attrs)
+      assert sub_task.completed == true
+      assert sub_task.description == "some description"
+      assert sub_task.name == "some name"
+    end
+
+    test "create_sub_task/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = SubTasks.create_sub_task(@invalid_attrs)
+    end
+
+    test "update_sub_task/2 with valid data updates the sub_task" do
+      sub_task = sub_task_fixture()
+      update_attrs = %{completed: false, description: "some updated description", name: "some updated name"}
+
+      assert {:ok, %SubTask{} = sub_task} = SubTasks.update_sub_task(sub_task, update_attrs)
+      assert sub_task.completed == false
+      assert sub_task.description == "some updated description"
+      assert sub_task.name == "some updated name"
+    end
+
+    test "update_sub_task/2 with invalid data returns error changeset" do
+      sub_task = sub_task_fixture()
+      assert {:error, %Ecto.Changeset{}} = SubTasks.update_sub_task(sub_task, @invalid_attrs)
+      assert sub_task == SubTasks.get_sub_task!(sub_task.id)
+    end
+
+    test "delete_sub_task/1 deletes the sub_task" do
+      sub_task = sub_task_fixture()
+      assert {:ok, %SubTask{}} = SubTasks.delete_sub_task(sub_task)
+      assert_raise Ecto.NoResultsError, fn -> SubTasks.get_sub_task!(sub_task.id) end
+    end
+
+    test "change_sub_task/1 returns a sub_task changeset" do
+      sub_task = sub_task_fixture()
+      assert %Ecto.Changeset{} = SubTasks.change_sub_task(sub_task)
+    end
+  end
+end

--- a/test/taskify/sub_tasks_test.exs
+++ b/test/taskify/sub_tasks_test.exs
@@ -8,34 +8,41 @@ defmodule Taskify.SubTasksTest do
 
     import Taskify.SubTasksFixtures
 
+    setup [:build_task]
+
     @invalid_attrs %{completed: nil, description: nil, name: nil}
 
-    test "list_sub_tasks/0 returns all sub_tasks" do
-      sub_task = sub_task_fixture()
-      assert SubTasks.list_sub_tasks() == [sub_task]
+    test "list_sub_tasks/1 returns all sub_tasks", %{task: task} do
+      sub_task = sub_task_fixture(task)
+      assert SubTasks.list_sub_tasks(task) == [sub_task]
     end
 
-    test "get_sub_task!/1 returns the sub_task with given id" do
-      sub_task = sub_task_fixture()
-      assert SubTasks.get_sub_task!(sub_task.id) == sub_task
+    test "get_sub_task!/2 returns the sub_task with given id", %{task: task} do
+      sub_task = sub_task_fixture(task)
+      assert SubTasks.get_sub_task!(task, sub_task.id) == sub_task
     end
 
-    test "create_sub_task/1 with valid data creates a sub_task" do
+    test "create_sub_task/2 with valid data creates a sub_task", %{task: task} do
       valid_attrs = %{completed: true, description: "some description", name: "some name"}
 
-      assert {:ok, %SubTask{} = sub_task} = SubTasks.create_sub_task(valid_attrs)
+      assert {:ok, %SubTask{} = sub_task} = SubTasks.create_sub_task(task, valid_attrs)
       assert sub_task.completed == true
       assert sub_task.description == "some description"
       assert sub_task.name == "some name"
     end
 
-    test "create_sub_task/1 with invalid data returns error changeset" do
-      assert {:error, %Ecto.Changeset{}} = SubTasks.create_sub_task(@invalid_attrs)
+    test "create_sub_task/2 with invalid data returns error changeset", %{task: task} do
+      assert {:error, %Ecto.Changeset{}} = SubTasks.create_sub_task(task, @invalid_attrs)
     end
 
-    test "update_sub_task/2 with valid data updates the sub_task" do
-      sub_task = sub_task_fixture()
-      update_attrs = %{completed: false, description: "some updated description", name: "some updated name"}
+    test "update_sub_task/2 with valid data updates the sub_task", %{task: task} do
+      sub_task = sub_task_fixture(task)
+
+      update_attrs = %{
+        completed: false,
+        description: "some updated description",
+        name: "some updated name"
+      }
 
       assert {:ok, %SubTask{} = sub_task} = SubTasks.update_sub_task(sub_task, update_attrs)
       assert sub_task.completed == false
@@ -43,21 +50,26 @@ defmodule Taskify.SubTasksTest do
       assert sub_task.name == "some updated name"
     end
 
-    test "update_sub_task/2 with invalid data returns error changeset" do
-      sub_task = sub_task_fixture()
+    test "update_sub_task/2 with invalid data returns error changeset", %{task: task} do
+      sub_task = sub_task_fixture(task)
       assert {:error, %Ecto.Changeset{}} = SubTasks.update_sub_task(sub_task, @invalid_attrs)
-      assert sub_task == SubTasks.get_sub_task!(sub_task.id)
+      assert sub_task == SubTasks.get_sub_task!(task, sub_task.id)
     end
 
-    test "delete_sub_task/1 deletes the sub_task" do
-      sub_task = sub_task_fixture()
+    test "delete_sub_task/1 deletes the sub_task", %{task: task} do
+      sub_task = sub_task_fixture(task)
       assert {:ok, %SubTask{}} = SubTasks.delete_sub_task(sub_task)
-      assert_raise Ecto.NoResultsError, fn -> SubTasks.get_sub_task!(sub_task.id) end
+      assert_raise Ecto.NoResultsError, fn -> SubTasks.get_sub_task!(task, sub_task.id) end
     end
 
-    test "change_sub_task/1 returns a sub_task changeset" do
-      sub_task = sub_task_fixture()
+    test "change_sub_task/1 returns a sub_task changeset", %{task: task} do
+      sub_task = sub_task_fixture(task)
       assert %Ecto.Changeset{} = SubTasks.change_sub_task(sub_task)
     end
+  end
+
+  defp build_task(_) do
+    user = Taskify.AccountsFixtures.user_fixture()
+    %{task: Taskify.TasksFixtures.task_fixture(user)}
   end
 end

--- a/test/taskify_web/controllers/sub_task_controller_test.exs
+++ b/test/taskify_web/controllers/sub_task_controller_test.exs
@@ -1,0 +1,84 @@
+defmodule TaskifyWeb.SubTaskControllerTest do
+  use TaskifyWeb.ConnCase
+
+  import Taskify.SubTasksFixtures
+
+  @create_attrs %{completed: true, description: "some description", name: "some name"}
+  @update_attrs %{completed: false, description: "some updated description", name: "some updated name"}
+  @invalid_attrs %{completed: nil, description: nil, name: nil}
+
+  describe "index" do
+    test "lists all sub_tasks", %{conn: conn} do
+      conn = get(conn, Routes.sub_task_path(conn, :index))
+      assert html_response(conn, 200) =~ "Listing Sub tasks"
+    end
+  end
+
+  describe "new sub_task" do
+    test "renders form", %{conn: conn} do
+      conn = get(conn, Routes.sub_task_path(conn, :new))
+      assert html_response(conn, 200) =~ "New Sub task"
+    end
+  end
+
+  describe "create sub_task" do
+    test "redirects to show when data is valid", %{conn: conn} do
+      conn = post(conn, Routes.sub_task_path(conn, :create), sub_task: @create_attrs)
+
+      assert %{id: id} = redirected_params(conn)
+      assert redirected_to(conn) == Routes.sub_task_path(conn, :show, id)
+
+      conn = get(conn, Routes.sub_task_path(conn, :show, id))
+      assert html_response(conn, 200) =~ "Show Sub task"
+    end
+
+    test "renders errors when data is invalid", %{conn: conn} do
+      conn = post(conn, Routes.sub_task_path(conn, :create), sub_task: @invalid_attrs)
+      assert html_response(conn, 200) =~ "New Sub task"
+    end
+  end
+
+  describe "edit sub_task" do
+    setup [:create_sub_task]
+
+    test "renders form for editing chosen sub_task", %{conn: conn, sub_task: sub_task} do
+      conn = get(conn, Routes.sub_task_path(conn, :edit, sub_task))
+      assert html_response(conn, 200) =~ "Edit Sub task"
+    end
+  end
+
+  describe "update sub_task" do
+    setup [:create_sub_task]
+
+    test "redirects when data is valid", %{conn: conn, sub_task: sub_task} do
+      conn = put(conn, Routes.sub_task_path(conn, :update, sub_task), sub_task: @update_attrs)
+      assert redirected_to(conn) == Routes.sub_task_path(conn, :show, sub_task)
+
+      conn = get(conn, Routes.sub_task_path(conn, :show, sub_task))
+      assert html_response(conn, 200) =~ "some updated description"
+    end
+
+    test "renders errors when data is invalid", %{conn: conn, sub_task: sub_task} do
+      conn = put(conn, Routes.sub_task_path(conn, :update, sub_task), sub_task: @invalid_attrs)
+      assert html_response(conn, 200) =~ "Edit Sub task"
+    end
+  end
+
+  describe "delete sub_task" do
+    setup [:create_sub_task]
+
+    test "deletes chosen sub_task", %{conn: conn, sub_task: sub_task} do
+      conn = delete(conn, Routes.sub_task_path(conn, :delete, sub_task))
+      assert redirected_to(conn) == Routes.sub_task_path(conn, :index)
+
+      assert_error_sent 404, fn ->
+        get(conn, Routes.sub_task_path(conn, :show, sub_task))
+      end
+    end
+  end
+
+  defp create_sub_task(_) do
+    sub_task = sub_task_fixture()
+    %{sub_task: sub_task}
+  end
+end

--- a/test/taskify_web/controllers/sub_task_controller_test.exs
+++ b/test/taskify_web/controllers/sub_task_controller_test.exs
@@ -3,37 +3,44 @@ defmodule TaskifyWeb.SubTaskControllerTest do
 
   import Taskify.SubTasksFixtures
 
+  setup [:register_and_log_in_user, :create_task]
+
   @create_attrs %{completed: true, description: "some description", name: "some name"}
-  @update_attrs %{completed: false, description: "some updated description", name: "some updated name"}
+  @update_attrs %{
+    completed: false,
+    description: "some updated description",
+    name: "some updated name"
+  }
   @invalid_attrs %{completed: nil, description: nil, name: nil}
 
   describe "index" do
-    test "lists all sub_tasks", %{conn: conn} do
-      conn = get(conn, Routes.sub_task_path(conn, :index))
+    test "lists all sub_tasks", %{conn: conn, task: task} do
+      conn = get(conn, Routes.task_sub_task_path(conn, :index, task))
       assert html_response(conn, 200) =~ "Listing Sub tasks"
     end
   end
 
   describe "new sub_task" do
-    test "renders form", %{conn: conn} do
-      conn = get(conn, Routes.sub_task_path(conn, :new))
+    test "renders form", %{conn: conn, task: task} do
+      conn = get(conn, Routes.task_sub_task_path(conn, :new, task))
       assert html_response(conn, 200) =~ "New Sub task"
     end
   end
 
   describe "create sub_task" do
-    test "redirects to show when data is valid", %{conn: conn} do
-      conn = post(conn, Routes.sub_task_path(conn, :create), sub_task: @create_attrs)
+    test "redirects to show when data is valid", %{conn: conn, task: task} do
+      conn = post(conn, Routes.task_sub_task_path(conn, :create, task), sub_task: @create_attrs)
 
       assert %{id: id} = redirected_params(conn)
-      assert redirected_to(conn) == Routes.sub_task_path(conn, :show, id)
+      assert redirected_to(conn) == Routes.task_sub_task_path(conn, :show, task, id)
 
-      conn = get(conn, Routes.sub_task_path(conn, :show, id))
+      conn = get(conn, Routes.task_sub_task_path(conn, :show, task, id))
       assert html_response(conn, 200) =~ "Show Sub task"
     end
 
-    test "renders errors when data is invalid", %{conn: conn} do
-      conn = post(conn, Routes.sub_task_path(conn, :create), sub_task: @invalid_attrs)
+    test "renders errors when data is invalid", %{conn: conn, task: task} do
+      conn = post(conn, Routes.task_sub_task_path(conn, :create, task), sub_task: @invalid_attrs)
+
       assert html_response(conn, 200) =~ "New Sub task"
     end
   end
@@ -41,8 +48,8 @@ defmodule TaskifyWeb.SubTaskControllerTest do
   describe "edit sub_task" do
     setup [:create_sub_task]
 
-    test "renders form for editing chosen sub_task", %{conn: conn, sub_task: sub_task} do
-      conn = get(conn, Routes.sub_task_path(conn, :edit, sub_task))
+    test "renders form for editing chosen sub_task", %{conn: conn, sub_task: sub_task, task: task} do
+      conn = get(conn, Routes.task_sub_task_path(conn, :edit, task, sub_task))
       assert html_response(conn, 200) =~ "Edit Sub task"
     end
   end
@@ -50,16 +57,24 @@ defmodule TaskifyWeb.SubTaskControllerTest do
   describe "update sub_task" do
     setup [:create_sub_task]
 
-    test "redirects when data is valid", %{conn: conn, sub_task: sub_task} do
-      conn = put(conn, Routes.sub_task_path(conn, :update, sub_task), sub_task: @update_attrs)
-      assert redirected_to(conn) == Routes.sub_task_path(conn, :show, sub_task)
+    test "redirects when data is valid", %{conn: conn, sub_task: sub_task, task: task} do
+      conn =
+        put(conn, Routes.task_sub_task_path(conn, :update, task, sub_task),
+          sub_task: @update_attrs
+        )
 
-      conn = get(conn, Routes.sub_task_path(conn, :show, sub_task))
+      assert redirected_to(conn) == Routes.task_sub_task_path(conn, :show, task, sub_task)
+
+      conn = get(conn, Routes.task_sub_task_path(conn, :show, task, sub_task))
       assert html_response(conn, 200) =~ "some updated description"
     end
 
-    test "renders errors when data is invalid", %{conn: conn, sub_task: sub_task} do
-      conn = put(conn, Routes.sub_task_path(conn, :update, sub_task), sub_task: @invalid_attrs)
+    test "renders errors when data is invalid", %{conn: conn, sub_task: sub_task, task: task} do
+      conn =
+        put(conn, Routes.task_sub_task_path(conn, :update, task, sub_task),
+          sub_task: @invalid_attrs
+        )
+
       assert html_response(conn, 200) =~ "Edit Sub task"
     end
   end
@@ -67,18 +82,23 @@ defmodule TaskifyWeb.SubTaskControllerTest do
   describe "delete sub_task" do
     setup [:create_sub_task]
 
-    test "deletes chosen sub_task", %{conn: conn, sub_task: sub_task} do
-      conn = delete(conn, Routes.sub_task_path(conn, :delete, sub_task))
-      assert redirected_to(conn) == Routes.sub_task_path(conn, :index)
+    test "deletes chosen sub_task", %{conn: conn, sub_task: sub_task, task: task} do
+      conn = delete(conn, Routes.task_sub_task_path(conn, :delete, task, sub_task))
+      assert redirected_to(conn) == Routes.task_sub_task_path(conn, :index, task)
 
       assert_error_sent 404, fn ->
-        get(conn, Routes.sub_task_path(conn, :show, sub_task))
+        get(conn, Routes.task_sub_task_path(conn, :show, task, sub_task))
       end
     end
   end
 
-  defp create_sub_task(_) do
-    sub_task = sub_task_fixture()
+  defp create_task(%{user: user}) do
+    task = Taskify.TasksFixtures.task_fixture(user)
+    %{task: task}
+  end
+
+  defp create_sub_task(%{task: task}) do
+    sub_task = sub_task_fixture(task)
     %{sub_task: sub_task}
   end
 end


### PR DESCRIPTION
# Task 005 - Create sub-tasks as nested resources

Allow users to add sub-tasks to their existing tasks

## Learning Goals
- Learning how to use the `mix phx.gen.context`
- Learning how to use nested resources
- An introduction to [Plug](https://hexdocs.pm/phoenix/plug.html)

## Screenshots


https://user-images.githubusercontent.com/5225249/201357208-1457506b-1d7c-473a-ad3d-7009797b0a9f.mov



## Steps

Let’s follow a similar path as Tasks resource, but, this time, 
using only the generator for contexts

Run:
```
mix phx.gen.context SubTasks SubTask sub_tasks name:string description:text completed:boolean task_id:references:tasks
```


In which:

- `mix phx.gen.context` will create the context, the ecto schema, database migration and tests

- `SubTasks` is the context name

- `SubTasks.SubTask` is the Ecto schema name

- `sub_tasks` is the database table name for the ecto schema

- `name:string description:text completed:boolean task_id:references:tasks` is the list of fields and their data types to represent a SubTask in the database


Please, do not run yet the created migration


Let's update the generated migration, forcing data integrity with `null: false` and allowing to cascade delete sub-tasks when the associated task is deleted:

```elixir
    create table(:sub_tasks) do
      add :name, :string, null: false
      add :description, :text
      add :completed, :boolean, default: false, null: false
      add :task_id, references(:tasks, on_delete: :delete_all), null: false

      timestamps()
    end
```


The, let's update SubTasks context and its tests to accept the task as an argument and 
only load sub-tasks of a given task:
See: 
- https://github.com/elainenaomi/taskify/blob/b855bf711cd6ae488fb77eec572cf7d029cd2a6a/lib/taskify/sub_tasks.ex

Don't forgot to update the Ecto schema for SubTask and Task - uses belongs_to and has_many
macros to define the association between structs:
See: 
- https://github.com/elainenaomi/taskify/blob/b855bf711cd6ae488fb77eec572cf7d029cd2a6a/lib/taskify/sub_tasks/sub_task.ex
- https://github.com/elainenaomi/taskify/blob/b855bf711cd6ae488fb77eec572cf7d029cd2a6a/lib/taskify/tasks/task.ex

Now, let's add `/sub_tasks` path as a nested resource with:
```
    resources "/tasks", TaskController do
      resources "/sub_tasks", SubTaskController
    end
```

Note: it is using the same pipeline as TaskController, so, it will require authentication 🎉 
It will allow us to use the path to identify which task the sub-tasks should be associated with.





When running `mix phx.routes`:

```
      task_sub_task_path  GET     /tasks/:task_id/sub_tasks              TaskifyWeb.TaskifyWeb.SubTaskController :index
      task_sub_task_path  GET     /tasks/:task_id/sub_tasks/:id/edit     TaskifyWeb.TaskifyWeb.SubTaskController :edit
      task_sub_task_path  GET     /tasks/:task_id/sub_tasks/new          TaskifyWeb.TaskifyWeb.SubTaskController :new
      task_sub_task_path  GET     /tasks/:task_id/sub_tasks/:id          TaskifyWeb.TaskifyWeb.SubTaskController :show
      task_sub_task_path  POST    /tasks/:task_id/sub_tasks              TaskifyWeb.TaskifyWeb.SubTaskController :create
      task_sub_task_path  PATCH   /tasks/:task_id/sub_tasks/:id          TaskifyWeb.TaskifyWeb.SubTaskController :update
                          PUT     /tasks/:task_id/sub_tasks/:id          TaskifyWeb.TaskifyWeb.SubTaskController :update
      task_sub_task_path  DELETE  /tasks/:task_id/sub_tasks/:id          TaskifyWeb.TaskifyWeb.SubTaskController :delete
```

Now, let's follow the steps to understand how to fetch the task_id parameter creating the SubTaskController and a basic view/template:
- Initial version of SubTaskController, view and template: https://github.com/elainenaomi/taskify/pull/6/commits/a61f750a1670f0483cb7b824f57830bbe1295129


Now, let's create the SubTasks resources templates with:

```
mix phx.gen.html SubTasks SubTask sub_tasks name:string description:text completed:boolean task_id:references:tasks --no-context --no-schema
```

Select interative mode and proceed with overwrite

- Do not overwrite SubTaskController
- Overwrite sub_task/index.html

This command will generate the templates for the CRUD operations in the
SubTasks context

Note: as we are working with a nested router, the automatic path for sub_tasks 
will be wrong, causing a compilation error when accessing, for instance, this path:
http://localhost:4000/tasks/1/sub_tasks

```
function TaskifyWeb.Router.Helpers.sub_task_path/2 is undefined or private
```

Let’s fix first the flow for listing sub-tasks:
https://github.com/elainenaomi/taskify/pull/6/commits/462964d33a2f3fadc25236384ddf0ee6109ce456

Then, let's add the `new` action (and fixing other paths)
https://github.com/elainenaomi/taskify/pull/6/commits/d5a9b75562ecd5b4dac8d173f843e63f0458e2f7

Refactoring: using a plug to fetch the task from the current_user:
https://github.com/elainenaomi/taskify/pull/6/commits/ccd54d95672cf96e45f498c18f3b4e70c3b8d95b

Add the `create` and `show` actions to SubTaskController:
https://github.com/elainenaomi/taskify/pull/6/commits/8d3094b7c6ccc30791086a922f9c427c4fccf093

Add `edit` and `update` actions to SubTaskController
https://github.com/elainenaomi/taskify/pull/6/commits/de2893b9ba415a5cb63a72fac61a91b89c7932f9

Add the `delete` action to SubTaskController
https://github.com/elainenaomi/taskify/pull/6/commits/79ebb69062334c7fdd3ec6f87c125e2393055e29

And, finally, fixes the broken tests:
https://github.com/elainenaomi/taskify/pull/6/commits/789071cf95622eb7420ec0edb7b80977f5437579

---

About Phoenix Context:

A Phoenix context encapsulates all business logic for a specific domain.
We can interact with a Phoenix context from controllers, channels, APIs, 
keeping following the Single Responsibility Principle.

We can change the business logic without touching the web layer :)

Having two resources related in the database does not mean they belong
to the same context.

Suggested approach: prefer distinct contexts per resource and refactor 
later if necessary; you can also break down a context into smaller contexts.

The goal is to avoid having a large context with loosely related entities/resources

About Rest API:
- RailsConf 2017: In Relentless Pursuit of REST by Derek Prior
https://www.youtube.com/watch?v=HctYHe-YjnE
