### PR TITLE
Task 006 - Show sub-task status on task list

### DIFF
--- a/lib/taskify/sub_tasks/sub_task.ex
+++ b/lib/taskify/sub_tasks/sub_task.ex
@@ -17,6 +17,6 @@ defmodule Taskify.SubTasks.SubTask do
   def changeset(sub_task, attrs) do
     sub_task
     |> cast(attrs, [:name, :description, :completed])
-    |> validate_required([:name, :description, :completed])
+    |> validate_required([:name, :completed])
   end
 end

--- a/lib/taskify/tasks.ex
+++ b/lib/taskify/tasks.ex
@@ -25,7 +25,11 @@ defmodule Taskify.Tasks do
   end
 
   defp user_tasks_query(query, %Accounts.User{id: user_id}) do
-    from(v in query, where: v.user_id == ^user_id, preload: [:user])
+    from(t in query,
+      left_join: s in assoc(t, :sub_tasks),
+      where: t.user_id == ^user_id,
+      preload: [:user, sub_tasks: s]
+    )
   end
 
   @doc """

--- a/lib/taskify_web/templates/sub_task/index.html.heex
+++ b/lib/taskify_web/templates/sub_task/index.html.heex
@@ -27,4 +27,5 @@
   </tbody>
 </table>
 
-<span><%= link "New Sub task", to: Routes.task_sub_task_path(@conn, :new, @task) %></span>
+<span><%= link "New Sub task", to: Routes.task_sub_task_path(@conn, :new, @task) %></span> |
+<span><%= link "Task", to: Routes.task_path(@conn, :show, @task) %></span>

--- a/lib/taskify_web/templates/task/index.html.heex
+++ b/lib/taskify_web/templates/task/index.html.heex
@@ -5,7 +5,7 @@
     <tr>
       <th>Name</th>
       <th>Description</th>
-
+      <th>Completed/ Total</th>
       <th></th>
     </tr>
   </thead>
@@ -14,7 +14,7 @@
     <tr>
       <td><%= task.name %></td>
       <td><%= task.description %></td>
-
+      <td><%= sub_tasks_status(task) %></td>
       <td>
         <span><%= link "Show", to: Routes.task_path(@conn, :show, task) %></span>
         <span><%= link "Edit", to: Routes.task_path(@conn, :edit, task) %></span>

--- a/lib/taskify_web/templates/task/show.html.heex
+++ b/lib/taskify_web/templates/task/show.html.heex
@@ -15,4 +15,5 @@
 </ul>
 
 <span><%= link "Edit", to: Routes.task_path(@conn, :edit, @task) %></span> |
-<span><%= link "Back", to: Routes.task_path(@conn, :index) %></span>
+<span><%= link "Back", to: Routes.task_path(@conn, :index) %></span> |
+<span><%= link "Sub-Tasks", to: Routes.task_sub_task_path(@conn, :index, @task) %></span>

--- a/lib/taskify_web/views/task_view.ex
+++ b/lib/taskify_web/views/task_view.ex
@@ -1,3 +1,12 @@
 defmodule TaskifyWeb.TaskView do
   use TaskifyWeb, :view
+
+  def sub_tasks_status(%{sub_tasks: sub_tasks}) when is_list(sub_tasks) and sub_tasks != [] do
+    completed = Enum.count(sub_tasks, & &1.completed)
+    total = Enum.count(sub_tasks)
+
+    "#{completed} / #{total}"
+  end
+
+  def sub_tasks_status(_), do: "0"
 end


### PR DESCRIPTION
# Task 006 - Show sub-task status on task list

Show how many sub-tasks were completed vs the total of sub-tasks per task

## Learning Goals
- Using left join with Ecto query

## Screenshot

<img width="1106" alt="Screen Shot 2022-11-11 at 11 19 34" src="https://user-images.githubusercontent.com/5225249/201359056-0279c325-54b3-4c8e-bce4-60275030a0ab.png">


## Steps

Update the task query to preload sub-tasks:
```
  defp user_tasks_query(query, %Accounts.User{id: user_id}) do
    from(t in query,
      left_join: s in assoc(t, :sub_tasks),
      where: t.user_id == ^user_id,
      preload: [:user, sub_tasks: s]
    )
  end
```

Then, create a `sub_tasks_status` function  in the View module to format the status based on the returned sub_tasks of a task

```
defmodule TaskifyWeb.TaskView do
  use TaskifyWeb, :view

  def sub_tasks_status(%{sub_tasks: sub_tasks}) when is_list(sub_tasks) and sub_tasks != [] do
    completed = Enum.count(sub_tasks, & &1.completed)
    total = Enum.count(sub_tasks)

    "#{completed} / #{total}"
  end

  def sub_tasks_status(_), do: "0"
end
```

Don't forgot to call the new function on the `task/index.html.heex` template :)

See:
https://github.com/elainenaomi/taskify/pull/7/commits/63590f0cc272b7c4e9dfa133a41e4dbfe0925fe4

